### PR TITLE
If nanoseconds > 999999499 datetime_from_sec_and_nano breaks

### DIFF
--- a/channelarchiver/utils.py
+++ b/channelarchiver/utils.py
@@ -135,7 +135,10 @@ def datetime_from_sec_and_nano(seconds, nanoseconds=0, tz=None):
     # We create the datetime in two steps to avoid the weird
     # microsecond rounding behaviour in Python 3.
     dt = datetime.datetime.fromtimestamp(seconds, utc)
-    dt = dt.replace(microsecond=int(round(1.e-3 * nanoseconds)))
+    if nanoseconds < 999999500:
+        dt = dt.replace(microsecond=int(round(1.e-3 * nanoseconds)))
+    else:
+        dt = datetime.datetime.fromtimestamp(seconds+1, utc)
     return dt.astimezone(tz)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,6 +113,13 @@ class TestUtils(unittest.TestCase):
         # Note nanoseconds get rounded off in conversion to microseconds
         self.assertEqual(dt, datetime.datetime(2013, 8, 17, 2, 20, 13, 123457, utils.utc))
 
+    def test_datetime_from_sec_and_nano_near_1e9_ns(self):
+        seconds = 1376706013
+        nanoseconds = 999999500
+        dt = utils.datetime_from_sec_and_nano(seconds, nanoseconds)
+        # Note nanoseconds get rounded off in conversion to microseconds
+        self.assertEqual(dt, datetime.datetime(2013, 8, 17, 2, 20, 14, 0, utils.utc))
+
     def test_datetime_from_sec_and_nano_with_utc(self):
         seconds = 1342129643
         nanoseconds = 123456789


### PR DESCRIPTION
A ValueError: microsecond must be in 0..999999 is raised. I tried to dt.replace seconds but that can fail if second is greater than 59 so I think creating a new datetime object is the easiest.